### PR TITLE
fix typo on man page

### DIFF
--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -181,7 +181,7 @@ Only keep objects that have a value in one of the columns
 \fB\  \fR\-\-hstore\-add\-index
 Create indices for the hstore columns during import.
 .TP
-\fB\-G\fR|\-\-melts\-geometry
+\fB\-G\fR|\-\-multi\-geometry
 Normally osm2pgsql splits multi\-part geometries into separate database rows per part.
 A single OSM id can therefore have several rows. With this option, PostgreSQL instead
 generates multi\-geometry features in the PostgreSQL tables.


### PR DESCRIPTION
I think it should be "multi-geometry" not "melts-geometry"
